### PR TITLE
adapt callback to node-style callback

### DIFF
--- a/node.bittrex.api.js
+++ b/node.bittrex.api.js
@@ -96,7 +96,7 @@ var NodeBittrexApi = function() {
                 request( request_options )
                     .pipe( JSONStream.parse() )
                     .pipe( es.mapSync( function( data ) {
-                        callback( data );
+                        callback( undefined, data );
                         ( ( opts.verbose ) 
                             ? console.log( "streamed from "+ request_options.uri +" in: %ds", ( Date.now() - start ) / 1000 ) : '' );
                     }));
@@ -105,7 +105,7 @@ var NodeBittrexApi = function() {
                 sendRequest()
                 .then( function( data ) {
                     
-                    callback( ( ( opts.cleartext ) ? data : JSON.parse( data ) ) );
+                    callback( undefined, ( ( opts.cleartext ) ? data : JSON.parse( data ) ) );
                     ( ( opts.verbose ) 
                         ? console.log( "requested from "+ request_options.uri +" in: %ds", ( Date.now() - start ) / 1000 ) : '' );
                 })


### PR DESCRIPTION
Error first callbacks are more node friendly and also mandatory to use this api with q promises.
For example, that enables to do:

``` javascript
Q.ninvoke(bittrex, 'getmarketsummaries').done(function( markets ) { console.log(markets); }
```

Be careful because that change will need update to code using this api.
