### PR TITLE
Removed dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "contributors": [],
   "license": "MIT",
   "dependencies": {
-    "q": ">= 1.0.1",
     "request": ">= 2.35.0",
     "JSONStream": ">= 0.8.4",
     "event-stream": ">= 3.1.5"


### PR DESCRIPTION
`q` isn't used in the code (I was going to change it over to bluebird, but then I realized Q doesn't show up anywhere)
